### PR TITLE
Fixed translation from sensor status

### DIFF
--- a/src/components/settings/moduleStatus.js
+++ b/src/components/settings/moduleStatus.js
@@ -14,7 +14,7 @@ class ModuleStatus extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      moduleStatus: [],
+      moduleStatus: {},
     };
     this.getStatus();
   }
@@ -26,13 +26,26 @@ class ModuleStatus extends Component {
   }
 
   render() {
-    const moduleList = this.state.moduleStatus.map(module => (
-      <li className="mb-1" key={module.name}>
-        {module.name}: &nbsp;
-        <span style={{ color: module.value ? 'green' : 'red' }}>
-          {T.translate(`settings.state.value.${module.value ? 'connected' : 'disconnected'}.${this.props.language}`)}
-        </span>
-      </li>));
+    const moduleList = [];
+    const whiteList = [
+      'notificationModule',
+      'fixedAccelerometer',
+      'mobileAccelerometer',
+      'pressureMat',
+    ];
+
+    for (const module in this.state.moduleStatus) {
+      if (whiteList.includes(module)) {
+        moduleList.push((
+          <li className="mb-1" key={module}>
+            {T.translate(`settings.state.value.${module}.${this.props.language}`)}: &nbsp;
+            <span style={{ color: this.state.moduleStatus[module] ? 'green' : 'red' }}>
+              {T.translate(`settings.state.value.${this.state.moduleStatus[module] ? 'connected' : 'disconnected'}.${this.props.language}`)}
+            </span>
+          </li>
+        ));
+      }
+    }
 
     return (
       <div className="row">

--- a/src/res/texts.yaml
+++ b/src/res/texts.yaml
@@ -410,6 +410,18 @@ settings:
       disconnected:
         FR: "Déconnecté"
         EN: "Disconnected"
+      notificationModule:
+        FR: "Module de notification"
+        EN: "Notification module"
+      fixedAccelerometer:
+        FR: "Accéléromètre fixe"
+        EN: "Fixed accelerometer"
+      mobileAccelerometer:
+        FR: "Accéléromètre mobile"
+        EN: "Mobile accelerometer"
+      pressureMat:
+        FR: "Tapis de pression"
+        EN: "Pressure Mat"
   modules:
     FR: "Capteurs"
     EN: "Sensors"


### PR DESCRIPTION
Translations now come as keys instead of names from the server. These adjustments allow multiple language support and is compatible with future versions of the server.

Note: The whitelist is recommended from ESLint. It is not my personal recommendation.